### PR TITLE
update ChineseSimplified.isl

### DIFF
--- a/ChineseSimplified.isl
+++ b/ChineseSimplified.isl
@@ -63,11 +63,11 @@ SetupFileCorrupt=安装文件已损坏。请获取程序的新副本。
 SetupFileCorruptOrWrongVer=安装文件已损坏，或是与这个安装程序的版本不兼容。请修正这个问题或获取新的程序副本。
 InvalidParameter=无效的命令行参数：%n%n%1
 SetupAlreadyRunning=安装程序正在运行。
-WindowsVersionNotSupported=这个程序不支持当前计算机运行的Windows版本。
-WindowsServicePackRequired=这个程序需要 %1 服务包 %2 或更高。
-NotOnThisPlatform=这个程序将不能运行于 %1。
-OnlyOnThisPlatform=这个程序必须运行于 %1。
-OnlyOnTheseArchitectures=这个程序只能在为下列处理器结构设计的Windows版本中进行安装：%n%n%1
+WindowsVersionNotSupported=这个程序不支持当前计算机运行的 Windows 版本。
+WindowsServicePackRequired=这个程序需要 %1 服务包 %2 或更高版本。
+NotOnThisPlatform=这个程序不能在 %1 上运行。
+OnlyOnThisPlatform=这个程序只能在 %1 上运行。
+OnlyOnTheseArchitectures=这个程序只能在为下列处理器结构设计的 Windows 版本中安装：%n%n%1
 WinVersionTooLowError=这个程序需要 %1 版本 %2 或更高。
 WinVersionTooHighError=这个程序不能安装于 %1 版本 %2 或更高。
 AdminPrivilegesRequired=在安装这个程序时您必须以管理员身份登录。
@@ -86,12 +86,12 @@ PrivilegesRequiredOverrideCurrentUser=只为我安装(&M)
 PrivilegesRequiredOverrideCurrentUserRecommended=只为我安装(&M) (建议选项)
 
 ; *** 其它错误
-ErrorCreatingDir=安装程序不能创建目录“%1”。
+ErrorCreatingDir=安装程序无法创建目录“%1”。
 ErrorTooManyFilesInDir=无法在目录“%1”中创建文件，因为里面包含太多文件
 
 ; *** 安装程序公共消息
 ExitSetupTitle=退出安装程序
-ExitSetupMessage=安装程序还未完成安装。如果您现在退出，程序将不能安装。%n%n您可以以后再运行安装程序完成安装。%n%n现在退出安装程序吗？
+ExitSetupMessage=安装程序尚未完成。如果现在退出，将不会安装该程序。%n%n您之后可以再次运行安装程序完成安装。%n%n现在退出安装程序吗？
 AboutSetupMenuItem=关于安装程序(&A)...
 AboutSetupTitle=关于安装程序
 AboutSetupMessage=%1 版本 %2%n%3%n%n%1 主页：%n%4
@@ -133,7 +133,7 @@ WizardPassword=密码
 PasswordLabel1=这个安装程序有密码保护。
 PasswordLabel3=请输入密码，然后点击“下一步”继续。密码区分大小写。
 PasswordEditLabel=密码(&P)：
-IncorrectPassword=您所输入的密码不正确，请重新输入。
+IncorrectPassword=您输入的密码不正确，请重新输入。
 
 ; *** “许可协议”向导页
 WizardLicense=许可协议
@@ -166,7 +166,7 @@ SelectDirBrowseLabel=点击“下一步”继续。如果您想选择其它文�
 DiskSpaceGBLabel=至少需要有 [gb] GB 的可用磁盘空间。
 DiskSpaceMBLabel=至少需要有 [mb] MB 的可用磁盘空间。
 CannotInstallToNetworkDrive=安装程序无法安装到一个网络驱动器。
-CannotInstallToUNCPath=安装程序无法安装到一个UNC路径。
+CannotInstallToUNCPath=安装程序无法安装到一个 UNC 路径。
 InvalidPath=您必须输入一个带驱动器卷标的完整路径，例如：%n%nC:\APP%n%n或UNC路径：%n%n\\server\share
 InvalidDrive=您选定的驱动器或 UNC 共享不存在或不能访问。请选择其它位置。
 DiskSpaceWarningTitle=磁盘空间不足
@@ -181,18 +181,18 @@ DirDoesntExist=文件夹：%n%n%1%n%n不存在。您想要创建此文件夹吗�
 
 ; *** “选择组件”向导页
 WizardSelectComponents=选择组件
-SelectComponentsDesc=您想安装哪些程序的组件？
-SelectComponentsLabel2=选择您想要安装的组件；清除您不想安装的组件。然后点击“下一步”继续。
+SelectComponentsDesc=您想安装哪些程序组件？
+SelectComponentsLabel2=选中您想安装的组件；取消您不想安装的组件。然后点击“下一步”继续。
 FullInstallation=完全安装
 ; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
 CompactInstallation=简洁安装
 CustomInstallation=自定义安装
 NoUninstallWarningTitle=组件已存在
-NoUninstallWarning=安装程序检测到下列组件已在您的电脑中安装：%n%n%1%n%n取消选定这些组件将不能卸载它们。%n%n您一定要继续吗？
+NoUninstallWarning=安装程序检测到下列组件已安装在您的电脑中：%n%n%1%n%n取消选中这些组件不会卸载它们。%n%n确定要继续吗？
 ComponentSize1=%1 KB
 ComponentSize2=%1 MB
-ComponentsDiskSpaceGBLabel=当前选择的组件至少需要 [gb] GB 的磁盘空间。
-ComponentsDiskSpaceMBLabel=当前选择的组件至少需要 [mb] MB 的磁盘空间。
+ComponentsDiskSpaceGBLabel=当前选择的组件需要至少 [gb] GB 的磁盘空间。
+ComponentsDiskSpaceMBLabel=当前选择的组件需要至少 [mb] MB 的磁盘空间。
 
 ; *** “选择附加任务”向导页
 WizardSelectTasks=选择附加任务
@@ -202,7 +202,7 @@ SelectTasksLabel2=选择您想要安装程序在安装 [name] 时执行的附加
 ; *** “选择开始菜单文件夹”向导页
 WizardSelectProgramGroup=选择开始菜单文件夹
 SelectStartMenuFolderDesc=安装程序应该在哪里放置程序的快捷方式？
-SelectStartMenuFolderLabel3=安装程序将在下列开始菜单文件夹中创建程序的快捷方式。
+SelectStartMenuFolderLabel3=安装程序将在下列“开始”菜单文件夹中创建程序的快捷方式。
 SelectStartMenuFolderBrowseLabel=点击“下一步”继续。如果您想选择其它文件夹，点击“浏览”。
 MustEnterGroupName=您必须输入一个文件夹名。
 GroupNameTooLong=文件夹名或路径太长。
@@ -212,13 +212,13 @@ NoProgramGroupCheck2=不创建开始菜单文件夹(&D)
 
 ; *** “准备安装”向导页
 WizardReady=准备安装
-ReadyLabel1=安装程序准备好了，现在可以开始安装 [name] 到您的电脑中。
-ReadyLabel2a=点击“安装”继续此安装程序。如果您想要重新考虑或修改任何设置，请点击“上一步”。
-ReadyLabel2b=点击“安装”继续此安装程序？
+ReadyLabel1=安装程序准备就绪，现在可以开始安装 [name] 到您的电脑。
+ReadyLabel2a=点击“安装”继续此安装程序。如果您想重新考虑或修改任何设置，点击“上一步”。
+ReadyLabel2b=点击“安装”继续此安装程序。
 ReadyMemoUserInfo=用户信息：
 ReadyMemoDir=目标位置：
 ReadyMemoType=安装类型：
-ReadyMemoComponents=选定组件：
+ReadyMemoComponents=已选择组件：
 ReadyMemoGroup=开始菜单文件夹：
 ReadyMemoTasks=附加任务：
 
@@ -231,35 +231,35 @@ ErrorDownloadFailed=下载失败：%1 %2
 ErrorDownloadSizeFailed=获取下载大小失败：%1 %2
 ErrorFileHash1=校验文件哈希失败：%1
 ErrorFileHash2=无效的文件哈希：预期 %1，实际 %2
-ErrorProgress=无效的进度：%1，总共%2
+ErrorProgress=无效的进度：%1 / %2
 ErrorFileSize=文件大小错误：预期 %1，实际 %2
 
 ; *** “正在准备安装”向导页
 WizardPreparing=正在准备安装
-PreparingDesc=安装程序正在准备安装 [name] 到您的电脑中。
-PreviousInstallNotCompleted=先前程序的安装/卸载未完成。您需要重新启动您的电脑才能完成安装。%n%n在重新启动电脑后，再运行安装完成 [name] 的安装。
+PreparingDesc=安装程序正在准备安装 [name] 到您的电脑。
+PreviousInstallNotCompleted=先前的程序安装或卸载未完成，您需要重启您的电脑以完成。%n%n在重启电脑后，再次运行安装程序以完成 [name] 的安装。
 CannotContinue=安装程序不能继续。请点击“取消”退出。
-ApplicationsFound=以下应用程序正在使用需要由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。
-ApplicationsFound2=以下应用程序正在使用需要由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。安装完成后，安装程序将尝试重新启动这些应用程序。
-CloseApplications=自动关闭该应用程序(&A)
-DontCloseApplications=不要关闭该应用程序(&D)
-ErrorCloseApplications=安装程序无法自动关闭所有应用程序。建议您在继续之前关闭所有使用需要由安装程序更新的文件的应用程序。
-PrepareToInstallNeedsRestart=安装程序必须重新启动计算机。重新启动计算机后，请再次运行安装程序以完成 [name] 的安装。%n%n是否立即重新启动？
+ApplicationsFound=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。
+ApplicationsFound2=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。安装完成后，安装程序将尝试重新启动这些应用程序。
+CloseApplications=自动关闭应用程序(&A)
+DontCloseApplications=不要关闭应用程序(&D)
+ErrorCloseApplications=安装程序无法自动关闭所有应用程序。建议您在继续之前，关闭所有在使用需要由安装程序更新的文件的应用程序。
+PrepareToInstallNeedsRestart=安装程序必须重启您的计算机。计算机重启后，请再次运行安装程序以完成 [name] 的安装。%n%n是否立即重新启动？
 
 ; *** “正在安装”向导页
 WizardInstalling=正在安装
-InstallingLabel=安装程序正在安装 [name] 到您的电脑中，请稍等。
+InstallingLabel=安装程序正在安装 [name] 到您的电脑，请稍候。
 
 ; *** “安装完成”向导页
 FinishedHeadingLabel=[name] 安装完成
 FinishedLabelNoIcons=安装程序已在您的电脑中安装了 [name]。
-FinishedLabel=安装程序已在您的电脑中安装了 [name]。此应用程序可以通过选择安装的快捷方式运行。
+FinishedLabel=安装程序已在您的电脑中安装了 [name]。您可以通过已安装的快捷方式运行此应用程序。
 ClickFinish=点击“完成”退出安装程序。
-FinishedRestartLabel=要完成 [name] 的安装，安装程序必须重新启动您的电脑。您想要立即重新启动吗？
-FinishedRestartMessage=要完成 [name] 的安装，安装程序必须重新启动您的电脑。%n%n您想要立即重新启动吗？
+FinishedRestartLabel=为完成 [name] 的安装，安装程序必须重新启动您的电脑。要立即重启吗？
+FinishedRestartMessage=为完成 [name] 的安装，安装程序必须重新启动您的电脑。%n%n要立即重启吗？
 ShowReadmeCheck=是，我想查阅自述文件
-YesRadio=是，立即重新启动电脑(&Y)
-NoRadio=否，稍后重新启动电脑(&N)
+YesRadio=是，立即重启电脑(&Y)
+NoRadio=否，稍后重启电脑(&N)
 ; used for example as 'Run MyProg.exe'
 RunEntryExec=运行 %1
 ; used for example as 'View Readme.txt'
@@ -269,7 +269,7 @@ RunEntryShellExec=查阅 %1
 ChangeDiskTitle=安装程序需要下一张磁盘
 SelectDiskLabel2=请插入磁盘 %1 并点击“确定”。%n%n如果这个磁盘中的文件可以在下列文件夹之外的文件夹中找到，请输入正确的路径或点击“浏览”。
 PathLabel=路径(&P)：
-FileNotInDir2=文件“%1”不能在“%2”定位。请插入正确的磁盘或选择其它文件夹。
+FileNotInDir2=“%2”中找不到文件“%1”。请插入正确的磁盘或选择其它文件夹。
 SelectDirectoryLabel=请指定下一张磁盘的位置。
 
 ; *** 安装状态消息
@@ -297,7 +297,7 @@ ErrorInternal2=内部错误：%1
 ErrorFunctionFailedNoCode=%1 失败
 ErrorFunctionFailed=%1 失败；错误代码 %2
 ErrorFunctionFailedWithMessage=%1 失败；错误代码 %2.%n%3
-ErrorExecutingProgram=不能执行文件：%n%1
+ErrorExecutingProgram=无法执行文件：%n%1
 
 ; *** 注册表错误
 ErrorRegOpenKey=打开注册表项时出错：%n%1\%2
@@ -305,69 +305,69 @@ ErrorRegCreateKey=创建注册表项时出错：%n%1\%2
 ErrorRegWriteKey=写入注册表项时出错：%n%1\%2
 
 ; *** INI 错误
-ErrorIniEntry=在文件“%1”中创建INI条目时出错。
+ErrorIniEntry=在文件“%1”中创建 INI 条目时出错。
 
 ; *** 文件复制错误
-FileAbortRetryIgnoreSkipNotRecommended=跳过这个文件(&S) (不推荐)
+FileAbortRetryIgnoreSkipNotRecommended=跳过此文件(&S) (不推荐)
 FileAbortRetryIgnoreIgnoreNotRecommended=忽略错误并继续(&I) (不推荐)
 SourceIsCorrupted=源文件已损坏
 SourceDoesntExist=源文件“%1”不存在
-ExistingFileReadOnly2=无法替换现有文件，因为它是只读的。
+ExistingFileReadOnly2=无法替换现有文件，它是只读的。
 ExistingFileReadOnlyRetry=移除只读属性并重试(&R)
 ExistingFileReadOnlyKeepExisting=保留现有文件(&K)
 ErrorReadingExistingDest=尝试读取现有文件时出错：
 FileExistsSelectAction=选择操作
 FileExists2=文件已经存在。
-FileExistsOverwriteExisting=覆盖已经存在的文件(&O)
+FileExistsOverwriteExisting=覆盖已存在的文件(&O)
 FileExistsKeepExisting=保留现有的文件(&K)
-FileExistsOverwriteOrKeepAll=为所有的冲突文件执行此操作(&D)
+FileExistsOverwriteOrKeepAll=为所有冲突文件执行此操作(&D)
 ExistingFileNewerSelectAction=选择操作
-ExistingFileNewer2=现有的文件比安装程序将要安装的文件更新。
-ExistingFileNewerOverwriteExisting=覆盖已经存在的文件(&O)
+ExistingFileNewer2=现有的文件比安装程序将要安装的文件还要新。
+ExistingFileNewerOverwriteExisting=覆盖已存在的文件(&O)
 ExistingFileNewerKeepExisting=保留现有的文件(&K) (推荐)
-ExistingFileNewerOverwriteOrKeepAll=为所有的冲突文件执行此操作(&D)
-ErrorChangingAttr=尝试改变下列现有的文件的属性时出错：
+ExistingFileNewerOverwriteOrKeepAll=为所有冲突文件执行此操作(&D)
+ErrorChangingAttr=尝试更改下列现有文件的属性时出错：
 ErrorCreatingTemp=尝试在目标目录创建文件时出错：
 ErrorReadingSource=尝试读取下列源文件时出错：
 ErrorCopying=尝试复制下列文件时出错：
-ErrorReplacingExistingFile=尝试替换现有的文件时出错：
-ErrorRestartReplace=重新启动替换失败：
-ErrorRenamingTemp=尝试重新命名以下目标目录中的一个文件时出错：
+ErrorReplacingExistingFile=尝试替换现有文件时出错：
+ErrorRestartReplace=重启并替换失败：
+ErrorRenamingTemp=尝试重命名下列目标目录中的一个文件时出错：
 ErrorRegisterServer=无法注册 DLL/OCX：%1
 ErrorRegSvr32Failed=RegSvr32 失败；退出代码 %1
-ErrorRegisterTypeLib=无法注册类型库：%1
+ErrorRegisterTypeLib=无法注册类库：%1
 
 ; *** 卸载显示名字标记
 ; used for example as 'My Program (32-bit)'
 UninstallDisplayNameMark=%1 (%2)
 ; used for example as 'My Program (32-bit, All users)'
 UninstallDisplayNameMarks=%1 (%2, %3)
-UninstallDisplayNameMark32Bit=32位
-UninstallDisplayNameMark64Bit=64位
+UninstallDisplayNameMark32Bit=32 位
+UninstallDisplayNameMark64Bit=64 位
 UninstallDisplayNameMarkAllUsers=所有用户
 UninstallDisplayNameMarkCurrentUser=当前用户
 
 ; *** 安装后错误
 ErrorOpeningReadme=尝试打开自述文件时出错。
-ErrorRestartingComputer=安装程序不能重新启动电脑，请手动重启。
+ErrorRestartingComputer=安装程序无法重启电脑，请手动重启。
 
 ; *** 卸载消息
 UninstallNotFound=文件“%1”不存在。无法卸载。
-UninstallOpenError=文件“%1”不能打开。无法卸载。
+UninstallOpenError=文件“%1”不能被打开。无法卸载。
 UninstallUnsupportedVer=此版本的卸载程序无法识别卸载日志文件“%1”的格式。无法卸载
-UninstallUnknownEntry=在卸载日志中遇到一个未知的条目 (%1)
-ConfirmUninstall=您确认想要完全删除 %1 及其所有组件吗？
-UninstallOnlyOnWin64=这个安装程序只能在64位Windows中进行卸载。
-OnlyAdminCanUninstall=这个安装的程序需要有管理员权限的用户才能卸载。
-UninstallStatusLabel=正在从您的电脑中删除 %1，请稍等。
-UninstalledAll=%1 已顺利地从您的电脑中删除。
-UninstalledMost=%1 卸载完成。%n%n有一些内容无法被删除。您可以手动删除它们。
-UninstalledAndNeedsRestart=要完成 %1 的卸载，您的电脑必须重新启动。%n%n您想立即重新启动电脑吗？
-UninstallDataCorrupted=文件“%1”已损坏，无法卸载
+UninstallUnknownEntry=卸载日志中遇到一个未知条目 (%1)
+ConfirmUninstall=您确认要完全移除 %1 及其所有组件吗？
+UninstallOnlyOnWin64=仅允许在 64 位 Windows 中卸载此程序。
+OnlyAdminCanUninstall=仅使用管理员权限的用户能完成此卸载。
+UninstallStatusLabel=正在从您的电脑中移除 %1，请稍候。
+UninstalledAll=已顺利从您的电脑中移除 %1。
+UninstalledMost=%1 卸载完成。%n%n有部分内容未能被删除，但您可以手动删除它们。
+UninstalledAndNeedsRestart=为完成 %1 的卸载，需要重启您的电脑。%n%n立即重启电脑吗？
+UninstallDataCorrupted=文件“%1”已损坏。无法卸载
 
 ; *** 卸载状态消息
-ConfirmDeleteSharedFileTitle=删除共享文件吗？
-ConfirmDeleteSharedFile2=系统中包含的下列共享文件已经不再被其它程序使用。您想要卸载程序删除这些共享文件吗？%n%n如果这些文件被删除，但还有程序正在使用这些文件，这些程序可能不能正确执行。如果您不能确定，选择“否”。把这些文件保留在系统中以免引起问题。
+ConfirmDeleteSharedFileTitle=删除共享的文件吗？
+ConfirmDeleteSharedFile2=系统表示下列共享的文件已不有其他程序使用。您希望卸载程序删除这些共享的文件吗？%n%n如果删除这些文件，但仍有程序在使用这些文件，则这些程序可能出现异常。如果您不能确定，请选择“否”，在系统中保留这些文件以免引发问题。
 SharedFileNameLabel=文件名：
 SharedFileLocationLabel=位置：
 WizardUninstalling=卸载状态
@@ -385,12 +385,12 @@ ShutdownBlockReasonUninstallingApp=正在卸载 %1。
 NameAndVersion=%1 版本 %2
 AdditionalIcons=附加快捷方式：
 CreateDesktopIcon=创建桌面快捷方式(&D)
-CreateQuickLaunchIcon=创建快速运行栏快捷方式(&Q)
+CreateQuickLaunchIcon=创建快速启动栏快捷方式(&Q)
 ProgramOnTheWeb=%1 网站
 UninstallProgram=卸载 %1
 LaunchProgram=运行 %1
 AssocFileExtension=将 %2 文件扩展名与 %1 建立关联(&A)
 AssocingFileExtension=正在将 %2 文件扩展名与 %1 建立关联...
-AutoStartProgramGroupDescription=启动组：
+AutoStartProgramGroupDescription=启动：
 AutoStartProgram=自动启动 %1
-AddonHostProgramNotFound=%1无法找到您所选择的文件夹。%n%n您想要继续吗？
+AddonHostProgramNotFound=您选择的文件夹中无法找到 %1。%n%n您要继续吗？


### PR DESCRIPTION
#### Changes proposed in this pull request:
- 应 https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation/issues/15 进行了一次校对优化。

中文英文间留出空格以风格一致。
unable译作无法。
个人认为“您所”的“所”可省略。“到您的电脑中”的“中”也是。
`ReadyLabel2b`原文是句号。
请稍等->请稍候。差不多。
`CloseApplications`等是复数，所以不称“该”。
个人倾向适当简称“重新启动”为“重启”，Windows 也已经如此。
“类库”是术语。
XP时代译作“快速启动”栏。
“您想要继续吗？”肯定是想，但要不要（该不该）是另一回事，“您要继续吗”或“确定继续吗”更加明确。

`OnlyOnTheseArchitectures`感觉语句还能优化，但无想法。
`ErrorProgress=无效的进度`不确定具体用途，但感觉“/”应该通用，之前“总共”后面无空格。
`AutoStartProgramGroupDescription`作用不确定，大概是自动启动+立即启动的选项，“启动组”感觉不明白、没必要。

`SetupAlreadyRunning=安装程序正在运行。`或许能改“已经运行”，但不改也行。“正在”有“进行中”的相近含义，但此提示可能是刚刚启动、启动后窗口忘记，或者卡死了。
括号前是否空格，仍存在不一致。以及是否要用全角括号。
个人倾向“此”代替“这个”，此PR中未改。个人倾向“其他”代替“其它”，差异和理由见网络讨论。